### PR TITLE
Add standardrb gem and reflect usage to README.md

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source "https://rubygems.org"
 gemspec
+group :development, :test do
+  gem "standardrb", "~> 1.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,16 +15,16 @@ GEM
     diff-lcs (1.4.4)
     hashdiff (1.0.1)
     method_source (1.0.0)
-    parallel (1.20.1)
-    parser (3.0.1.1)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.3)
-    regexp_parser (2.1.1)
+    regexp_parser (2.4.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -39,17 +39,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.15.0)
+    rubocop (1.29.1)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.5.0)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.13.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rake (0.5.1)
       rubocop
     rubocop-rspec (2.3.0)
@@ -58,7 +61,12 @@ GEM
     rubocop-shopify (2.1.0)
       rubocop (~> 1.13)
     ruby-progressbar (1.11.0)
-    unicode-display_width (2.0.0)
+    standard (1.12.1)
+      rubocop (= 1.29.1)
+      rubocop-performance (= 1.13.3)
+    standardrb (1.0.1)
+      standard
+    unicode-display_width (2.1.0)
     vcr (6.0.0)
     webmock (3.13.0)
       addressable (>= 2.3.6)
@@ -67,6 +75,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bloodbath!
@@ -77,6 +86,7 @@ DEPENDENCIES
   rubocop-rake (~> 0.5.1)
   rubocop-rspec (~> 2.3)
   rubocop-shopify (~> 2.1.0)
+  standardrb (~> 1.0)
   vcr (~> 6.0.0)
   webmock (~> 3.13.0)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GitHub release](https://img.shields.io/github/release/bloodbath-io/bloodbath-ruby.svg)](https://github.com/bloodbath-io/bloodbath-ruby/releases/)
 ![](https://ruby-gem-downloads-badge.herokuapp.com/bloodbath?type=total)
 
-
 # Bloodbath Ruby Library
 
 The Bloodbath Ruby library provides convenient access to the Bloodbath API from applications written in the Ruby language.
@@ -27,6 +26,7 @@ Or install it yourself as:
 ## Usage
 
 ### Configuration
+
 The library needs to be configured with your account's API key which is available in your [Bloodbath Dashboard](https://app.bloodbath.io/). Set `Bloodbath.api_key` to its value:
 
 ```ruby
@@ -35,6 +35,7 @@ Bloodbath.api_key = 'NTI6PASMD9BQhYtRh...'
 ```
 
 #### Events
+
 ```ruby
 # schedule an event
 Bloodbath::Event.schedule(
@@ -58,6 +59,7 @@ Bloodbath::Event.cancel('b7ccff...')
 For more documentation about how to use Bloodbath, don't hesitate to check [Bloodbath Docs](https://docs.bloodbath.io).
 
 ## Advanced usage
+
 ### Multi-threads
 
 If you want to schedule a lot of events at once, waiting for the response might be too slow, that's why we developped a multi-thread scheduling option for the Ruby library.
@@ -93,6 +95,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/bloodbath-io/bloodbath-ruby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/bloodbath-io/bloodbath-ruby/blob/master/CODE_OF_CONDUCT.md).
+
+**IMPORTANT:** This project uses [Standard](https://github.com/testdouble/standard) for formatting Ruby code. Please make sure to run `standardrb` before submitting pull requests.
 
 ## Code of Conduct
 

--- a/bloodbath.gemspec
+++ b/bloodbath.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/bloodbath-io/bloodbath-ruby/blob/main/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency("pry", "~> 0.14")

--- a/lib/bloodbath/configuration.rb
+++ b/lib/bloodbath/configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Bloodbath
   class Configuration
     attr_accessor :api_key, :api_base, :verbose

--- a/lib/bloodbath/event.rb
+++ b/lib/bloodbath/event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "net/http"
 require "pry"
 require "json"
@@ -13,7 +14,7 @@ module Bloodbath
 
       attr_reader :method, :endpoint, :body, :options, :config
 
-      def initialize(method:, endpoint:, body: nil, options:, config: Bloodbath.config)
+      def initialize(method:, endpoint:, options:, body: nil, config: Bloodbath.config)
         @method = method
         @endpoint = endpoint
         @body = body
@@ -105,7 +106,7 @@ module Bloodbath
 
     def initialize(wait_for_response: true)
       @options = {
-        wait_for_response: wait_for_response,
+        wait_for_response: wait_for_response
       }
     end
 

--- a/lib/bloodbath/utils/threading.rb
+++ b/lib/bloodbath/utils/threading.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:disable Style/ClassVars
+
 module Bloodbath
   module Utils
     module Threading

--- a/lib/bloodbath/utils/verbose.rb
+++ b/lib/bloodbath/utils/verbose.rb
@@ -1,5 +1,5 @@
-
 # frozen_string_literal: true
+
 module Bloodbath
   module Utils
     class Verbose
@@ -7,14 +7,16 @@ module Bloodbath
         COLORS = {
           red: 31,
           green: 32,
-          blue: 34,
+          blue: 34
         }.freeze
 
         def capture(label)
           result = yield
-          return puts """
-          #{screen("[VERBOSE]")} #{screen("#{label}:", color: :blue)} #{screen(result, color: :red)}
-          """ if verbose?
+          if verbose?
+            puts "
+            #{screen("[VERBOSE]")} #{screen("#{label}:", color: :blue)} #{screen(result, color: :red)}
+            "
+          end
         end
 
         private

--- a/spec/bloodbath/event_spec.rb
+++ b/spec/bloodbath/event_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe(Bloodbath::Event, vcr: true) do
   describe ".schedule" do
     let(:scheduled_for) { Time.now + 60 * 60 }
     let(:method) { :post }
-    let(:headers) { { 'Random-Header': "Something" } }
+    let(:headers) { {"Random-Header": "Something"} }
     let(:body) { "Random body" }
     let(:endpoint) { "https://api.fake-site.com" }
     let(:params) do
@@ -19,7 +19,7 @@ RSpec.describe(Bloodbath::Event, vcr: true) do
         method: method,
         headers: headers,
         body: body,
-        endpoint: endpoint,
+        endpoint: endpoint
       }
     end
 


### PR DESCRIPTION
To have a uniform formating, added ```standardrb gem``` to time in the same three ways:
   * Catch style issues & programmer errors early. Save precious code review time by eliminating back-and-forth between reviewer & contributor.
   * Automatically format code. Just run ```standardrb --fix``` and say goodbye to messy or inconsistent code.
 Updated README to reflect the above 




